### PR TITLE
VueのPropの型にPropTypeを使う

### DIFF
--- a/components/ProfileItem.vue
+++ b/components/ProfileItem.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from '@vue/composition-api';
+import { defineComponent } from '@vue/composition-api';
 
 export default defineComponent({
   name: 'ProfileItem',
@@ -27,7 +27,7 @@ export default defineComponent({
       required: true,
     },
     singleText: {
-      type: Boolean as PropType<boolean>,
+      type: Boolean,
       default (): boolean {
         return false;
       },

--- a/components/ProjectItem.vue
+++ b/components/ProjectItem.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed, PropType } from '@vue/composition-api';
 import { Project } from '~/types';
 
 interface Props {
@@ -46,7 +46,7 @@ export default defineComponent({
   name: 'ProjectItem',
   props: {
     project: {
-      type: Object,
+      type: Object as PropType<Project>,
       required: true,
     },
   },


### PR DESCRIPTION
# 概要

VueのPropの型にPropTypeを使う．
IDEの補完をいい感じにする．