### PR TITLE
GitHub ActionsのSlackの通知を失敗時だけにする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@v1.6
-        if: always()
+        if: failure()
         with:
           job_name: '*${{ github.workflow }}*'
           type: ${{ job.status }}


### PR DESCRIPTION
# 概要

GitHub ActionsのSlackの通知を失敗時だけにする．