### PR TITLE
Dockerのイメージをalpineからslimに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.3-alpine
+FROM node:12.22.3-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,10 @@ WORKDIR /app
 
 ENV HOST "0.0.0.0"
 
-RUN apk add --no-cache --update tzdata avahi-dev && \
-    apk add --no-cache --virtual .gyp python make g++ && \
-    apk upgrade --no-cache && \
-    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    apk del tzdata && \
-    rm -rf /var/cache/apk/*
+RUN apt update -y && \
+    apt install -y --no-install-recommends tzdata g++ make python && \
+    apt-get clean && \
+    rm -rf /var/lib/opt/lists/*
 
 COPY . /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,5 @@ services:
       - .:/app:cached
     ports:
       - "8080:3000"
+    environment:
+      - TZ


### PR DESCRIPTION
# 概要

Dockerのイメージをalpineからslimに変更する．
alpineだと上手く動かない場合が多いため，slimに変更．
イメージサイズの大きさは問題なし．