### PR TITLE
Composition APIを@nuxtjs/composition-apiに変更

### DIFF
--- a/components/LinkList.vue
+++ b/components/LinkList.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from '@vue/composition-api';
+import { defineComponent, PropType } from '@nuxtjs/composition-api';
 import { Link } from '~/types';
 
 export default defineComponent({

--- a/components/LinksSection.vue
+++ b/components/LinksSection.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 import LinkList from './LinkList';
 import { Link } from '~/types';
 

--- a/components/PageFooter.vue
+++ b/components/PageFooter.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent } from '@nuxtjs/composition-api';
 
 export default defineComponent({
   name: 'PageFooter',

--- a/components/ProfileItem.vue
+++ b/components/ProfileItem.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent } from '@nuxtjs/composition-api';
 
 export default defineComponent({
   name: 'ProfileItem',

--- a/components/ProfileSection.vue
+++ b/components/ProfileSection.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 import ProfileItem from './ProfileItem';
 
 export default defineComponent({

--- a/components/ProjectItem.vue
+++ b/components/ProjectItem.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, PropType } from '@vue/composition-api';
+import { defineComponent, computed, PropType } from '@nuxtjs/composition-api';
 import { Project } from '~/types';
 
 interface Props {

--- a/components/ProjectsSection.vue
+++ b/components/ProjectsSection.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 import ProjectItem from './ProjectItem';
 import { Link, Project } from '~/types';
 

--- a/components/Separator.vue
+++ b/components/Separator.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 
 interface Props {
   size: string;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -41,7 +41,6 @@ const config: NuxtConfig = {
   ** Plugins to load before mounting the App
   */
   plugins: [
-    '~/plugins/composition-api.ts',
   ],
 
   /*

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,6 +54,8 @@ const config: NuxtConfig = {
 
     '@nuxt/typescript-build',
 
+    '@nuxtjs/composition-api/module',
+
     '@nuxtjs/sitemap',
   ],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@nuxt/typescript-runtime": "2.1.0",
+    "@nuxtjs/composition-api": "^0.26.0",
     "@nuxtjs/sitemap": "2.4.0",
     "nuxt": "2.15.7",
     "ts-node": "10.0.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/node": "14.17.7",
     "@typescript-eslint/eslint-plugin": "4.29.0",
     "@typescript-eslint/parser": "4.29.0",
-    "@vue/composition-api": "0.6.7",
     "eslint": "7.32.0",
     "eslint-config-standard": "16.0.3",
     "eslint-plugin-import": "2.23.4",

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
 

--- a/pages/404.vue
+++ b/pages/404.vue
@@ -37,27 +37,29 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from '@nuxtjs/composition-api';
+import { defineComponent, computed, useMeta } from '@nuxtjs/composition-api';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
 
 export default defineComponent({
-  head () {
-    return {
-      title: this.title,
-      meta: [
-        { hid: 'description', name: 'description', content: `${this.title} - ${this.subtitle}` },
-        { hid: 'robots', name: 'robots', content: 'noindex,nofollow' },
-      ],
-    };
-  },
+  head: {},
   setup () {
     const title = computed<string>(() => '404 Not Found');
     const subtitle = computed<string>(() => 'hiroxto.net');
+    const description = computed<string>(() => `${title.value} - ${subtitle.value}`);
+
+    useMeta(() => ({
+      title: title.value,
+      meta: [
+        { hid: 'description', name: 'description', content: description.value },
+        { hid: 'robots', name: 'robots', content: 'noindex,nofollow' },
+      ],
+    }));
 
     return {
       title,
       subtitle,
+      description,
     };
   },
   components: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,24 +43,24 @@ import LinksSection from '~/components/LinksSection';
 import ProjectsSection from '~/components/ProjectsSection';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
-import { defineComponent, computed } from '@nuxtjs/composition-api';
+import { defineComponent, computed, useMeta } from '@nuxtjs/composition-api';
 
 export default defineComponent({
-  head () {
-    return {
-      title: this.title,
+  head: {},
+  setup () {
+    const title = computed(() => 'hiroxto.net');
+    const subTitle = computed(() => 'Home page of hiroxto.');
+
+    useMeta(() => ({
+      title: title.value,
       titleTemplate: '',
       meta: [
-        { hid: 'description', name: 'description', content: this.subTitle },
+        { hid: 'description', name: 'description', content: subTitle.value },
       ],
       link: [
         { rel: 'canonical', href: '/' },
       ],
-    };
-  },
-  setup () {
-    const title = computed(() => 'hiroxto.net');
-    const subTitle = computed(() => 'Home page of hiroxto.');
+    }));
 
     return {
       title,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,7 +43,7 @@ import LinksSection from '~/components/LinksSection';
 import ProjectsSection from '~/components/ProjectsSection';
 import Separator from '~/components/Separator';
 import PageFooter from '~/components/PageFooter';
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 
 export default defineComponent({
   head () {

--- a/plugins/composition-api.ts
+++ b/plugins/composition-api.ts
@@ -1,4 +1,0 @@
-import Vue from 'vue';
-import VueCompositionApi from '@vue/composition-api';
-
-Vue.use(VueCompositionApi);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1999,13 +1999,6 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/composition-api@0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.6.7.tgz#4481b547cea65dc936432f7efcf1a39f9c69420c"
-  integrity sha512-WAWEQK4urEsMNe3OyOp7VnMmegRZT2yRB3fDGLRXPMdfuo4+nM+uMEhUgDiUg9LFSXfLWhjwuFOJ2hnS2X7AUw==
-  dependencies:
-    tslib "^2.0.0"
-
 "@vue/composition-api@^1.0.4":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.5.tgz#c7cef457284096e75cc0894e0cb9a251f91eba3f"
@@ -10243,7 +10236,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.3.0:
+tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,6 +1358,19 @@
     webpack-node-externals "^3.0.0"
     webpackbar "^4.0.0"
 
+"@nuxtjs/composition-api@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/composition-api/-/composition-api-0.26.0.tgz#0fbda4fc942ca1e346b7c6d55a1fb331ff931a2a"
+  integrity sha512-+4L9YDEN5h/vBY6xbBKPMIhgxbPv7psE4IVgKlF+QIekou6oN8m0T+QR2JLE0dHKwzicUbZLCr1v2Qw5T7L48A==
+  dependencies:
+    "@vue/composition-api" "^1.0.4"
+    defu "^5.0.0"
+    estree-walker "^2.0.2"
+    fs-extra "^9.1.0"
+    magic-string "^0.25.7"
+    ufo "^0.7.7"
+    upath "^2.0.1"
+
 "@nuxtjs/eslint-module@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-module/-/eslint-module-3.0.2.tgz#45208e6e1b486beb6d0854777faf124751971bc6"
@@ -1992,6 +2005,13 @@
   integrity sha512-WAWEQK4urEsMNe3OyOp7VnMmegRZT2yRB3fDGLRXPMdfuo4+nM+uMEhUgDiUg9LFSXfLWhjwuFOJ2hnS2X7AUw==
   dependencies:
     tslib "^2.0.0"
+
+"@vue/composition-api@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.5.tgz#c7cef457284096e75cc0894e0cb9a251f91eba3f"
+  integrity sha512-F5jZiSTFvpnJD4geVc5KNY4eNS5NrfU/nZXachzxYorl56SDlh54rFVRm1QtXgdTj/kwvgixT4n0XfhZZpnoBA==
+  dependencies:
+    tslib "^2.3.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4469,6 +4489,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -6423,6 +6448,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -9461,6 +9493,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -10206,7 +10243,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
@@ -10302,7 +10339,7 @@ ua-parser-js@^0.7.28:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
-ufo@^0.7.4, ufo@^0.7.5:
+ufo@^0.7.4, ufo@^0.7.5, ufo@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.7.tgz#0062f9e5e790819b0fb23ca24d7c63a4011c036a"
   integrity sha512-N25aY3HBkJBnahm+2l4JRBBrX5I+JPakF/tDHYDTjd3wUR7iFLdyiPhj8mBwBz21v728BKwM9L9tgBfCntgdlw==


### PR DESCRIPTION
# 概要

Composition APIを`@nuxtjs/composition-api`に変更．
これに合わせて，以下を実施した．
- 自分で作っていたプラグインを削除し，`buildModules`に`@nuxtjs/composition-api/module`から登録する形に変更
- インポート元を`@vue/composition-api`から`@nuxtjs/composition-api`に変更
- headの定義をuseMetaを使うように変更